### PR TITLE
Fix cargo-playdate ignores metadata if assets cash-hit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-playdate"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-playdate"
-version = "0.3.9"
+version = "0.3.10"
 readme = "README.md"
 description = "Build tool for neat yellow console."
 keywords = ["playdate", "build", "cargo", "plugin", "cargo-subcommand"]

--- a/cargo/src/cli/mod.rs
+++ b/cargo/src/cli/mod.rs
@@ -377,6 +377,15 @@ fn compile_options(cmd: &Cmd, matches: &ArgMatches, ws: &Workspace<'_>) -> Cargo
 		Cmd::Build | Cmd::Package | Cmd::Migrate | Cmd::Assets => {
 			matches.compile_options(cfg, CompileMode::Build, Some(&ws), ProfileChecking::Custom)?
 		},
+
+		Cmd::New | Cmd::Init => {
+			let mut opts = CompileOptions::new(ws.config(), CompileMode::Check { test: false })?;
+			opts.build_config
+			    .requested_kinds
+			    .push(PlaydateTarget::Device.into());
+			opts
+		},
+
 		// allow only one crate:
 		Cmd::Run => {
 			matches.compile_options_for_single_package(cfg, CompileMode::Build, Some(&ws), ProfileChecking::Custom)?
@@ -385,14 +394,6 @@ fn compile_options(cmd: &Cmd, matches: &ArgMatches, ws: &Workspace<'_>) -> Cargo
 		// allow only one crate?
 		Cmd::Publish => {
 			matches.compile_options_for_single_package(cfg, CompileMode::Build, Some(&ws), ProfileChecking::Custom)?
-		},
-
-		Cmd::New | Cmd::Init => {
-			let mut opts = CompileOptions::new(ws.config(), CompileMode::Check { test: false })?;
-			opts.build_config
-			    .requested_kinds
-			    .push(PlaydateTarget::Device.into());
-			opts
 		},
 	};
 

--- a/cargo/src/package/mod.rs
+++ b/cargo/src/package/mod.rs
@@ -279,8 +279,9 @@ fn build_manifest<'l, Layout: playdate::layout::Layout>(config: &Config,
 		            log.status("Manifest", msg);
 	            });
 
-	let manifest = if let Some(metadata) = assets.map(|a| a.metadata.as_ref()) {
-		               Manifest::try_from_source(ManifestSource { package, metadata })
+	let manifest = if let Some(metadata) = assets.map(|a| a.metadata.as_ref()).flatten() {
+		               Manifest::try_from_source(ManifestSource { package,
+		                                                          metadata: metadata.into() })
 	               } else {
 		               let metadata = playdate_metadata(package);
 		               Manifest::try_from_source(ManifestSource { package,


### PR DESCRIPTION
It causes when no asses but `[package.metadata.playdate.assets.options]` is set.