### PR TITLE
Fix ctrl const

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "playdate-controls"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "playdate-display",
  "playdate-graphics",

--- a/api/ctrl/Cargo.toml
+++ b/api/ctrl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "playdate-controls"
-version = "0.3.2"
+version = "0.3.3"
 readme = "README.md"
 description = "High-level controls API built on-top of Playdate API"
 keywords = ["playdate", "sdk", "api", "gamedev"]

--- a/api/ctrl/src/buttons.rs
+++ b/api/ctrl/src/buttons.rs
@@ -4,7 +4,6 @@ use core::ops::BitAnd;
 use sys::ffi::PDButtons;
 
 
-#[const_trait]
 pub trait PDButtonsExt: Sized + BitAnd<Self> {
 	#![allow(non_snake_case)]
 


### PR DESCRIPTION
Remove `#[const_trait]` to build on latest nightly without incomplete `effects` feature.