### PR TITLE
Split `init` tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -248,12 +248,19 @@ jobs:
       #     sudo apt -y install libwebkit2gtk-4.0-dev
 
       - name: Test
+        run: cargo test -p=cargo-playdate -- --nocapture
+
+      - name: Test (init::)
+        env:
+          RUSTFLAGS: --cfg init_tests
         run: |
-          cargo test -p=cargo-playdate -- --nocapture ${{ runner.os == 'Windows' && '--test-threads=1' || '' }}
-          rm -rf ./target/tmp
+          cargo test -p=cargo-playdate init:: -- --nocapture ${{ runner.os == 'Windows' && '--test-threads=1' || '' }}
+
+      - name: Clean tmp
+        run: rm -rf ./target/tmp
 
       # This test is flickering on GH CI 🤷🏻‍♂️
-      - name: Execution
+      - name: Test Execution
         if: runner.os == 'macOS' && contains(github.event.head_commit.message, 'execution')
         env:
           RUSTFLAGS: --cfg exec_tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-playdate"
-version = "0.4.0-alpha.3"
+version = "0.4.0-beta.1"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-playdate"
-version = "0.4.0-alpha.3"
+version = "0.4.0-beta.1"
 readme = "README.md"
 description = "Build tool for neat yellow console."
 keywords = ["playdate", "build", "cargo", "plugin", "cargo-subcommand"]

--- a/cargo/tests/init/init.rs
+++ b/cargo/tests/init/init.rs
@@ -37,6 +37,7 @@ fn run(crate_name: &str,
 
 
 #[test]
+#[cfg_attr(not(init_tests), ignore = "set RUSTFLAGS='--cfg init_tests' to enable.")]
 fn create_lib() -> Result<()> {
 	let args = ["--full-config", "--full-metadata"].into_iter().map(OsStr::new);
 
@@ -51,6 +52,7 @@ fn create_lib() -> Result<()> {
 
 
 #[test]
+#[cfg_attr(not(init_tests), ignore = "set RUSTFLAGS='--cfg init_tests' to enable.")]
 fn create_bin() -> Result<()> {
 	let args = ["--full-config", "--full-metadata"].into_iter().map(OsStr::new);
 
@@ -64,6 +66,7 @@ fn create_bin() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(init_tests), ignore = "set RUSTFLAGS='--cfg init_tests' to enable.")]
 fn create_default() -> Result<()> {
 	let args = ["--full-config", "--full-metadata"].into_iter().map(OsStr::new);
 

--- a/cargo/tests/init/new.rs
+++ b/cargo/tests/init/new.rs
@@ -37,6 +37,7 @@ fn run(crate_name: &str,
 
 
 #[test]
+#[cfg_attr(not(init_tests), ignore = "set RUSTFLAGS='--cfg init_tests' to enable.")]
 fn create_lib() -> Result<()> {
 	let args = ["--full-config", "--full-metadata"].into_iter().map(OsStr::new);
 
@@ -51,6 +52,7 @@ fn create_lib() -> Result<()> {
 
 
 #[test]
+#[cfg_attr(not(init_tests), ignore = "set RUSTFLAGS='--cfg init_tests' to enable.")]
 fn create_bin() -> Result<()> {
 	let args = ["--full-config", "--full-metadata"].into_iter().map(OsStr::new);
 
@@ -64,6 +66,7 @@ fn create_bin() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(init_tests), ignore = "set RUSTFLAGS='--cfg init_tests' to enable.")]
 fn create_default() -> Result<()> {
 	let args = ["--full-config", "--full-metadata"].into_iter().map(OsStr::new);
 


### PR DESCRIPTION
Now `init` / `new` tests are behind the cfg-flag.