### PR TITLE
Fix cargo-playdate error "No packages has been produced"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ dependencies = [
  "futures-lite 2.3.0",
  "parking",
  "polling 3.6.0",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -256,26 +256,26 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+checksum = "afe66191c335039c7bb78f99dc7520b0cbb166b3a1cb33a03f53d8a1c6f2afda"
 dependencies = [
  "async-io 2.3.2",
- "async-lock 2.8.0",
+ "async-lock 3.3.0",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -324,7 +324,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -341,7 +341,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -462,7 +462,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.59",
+ "syn 2.0.60",
  "which 4.4.2",
 ]
 
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-playdate"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -738,7 +738,7 @@ dependencies = [
  "serde_json",
  "target",
  "toml",
- "toml_edit 0.22.9",
+ "toml_edit 0.22.12",
  "try-lazy-init",
  "walkdir",
  "zip",
@@ -785,12 +785,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -875,7 +876,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1464,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
 
 [[package]]
 name = "filetime"
@@ -1606,7 +1607,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2032,7 +2033,7 @@ dependencies = [
  "itoa",
  "libc",
  "memmap2",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "smallvec",
  "thiserror",
 ]
@@ -2056,7 +2057,7 @@ checksum = "1dff438f14e67e7713ab9332f5fd18c8f20eb7eb249494f6c2bf170522224032"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2194,7 +2195,7 @@ dependencies = [
  "gix-command",
  "gix-config-value",
  "parking_lot 0.12.1",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "thiserror",
 ]
 
@@ -2851,9 +2852,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -2905,7 +2906,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3145,7 +3146,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3209,7 +3210,7 @@ checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3378,9 +3379,9 @@ dependencies = [
 
 [[package]]
 name = "nusb"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac267a828c32759883a6097809fc4c32d76925099725aae562717cb023b431c"
+checksum = "dccb3bb9c89ba9393f2f723da29221a39a3310c3950fbe5896eec05daa82753e"
 dependencies = [
  "atomic-waker",
  "core-foundation",
@@ -3388,7 +3389,7 @@ dependencies = [
  "io-kit-sys",
  "log",
  "once_cell",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "slab",
  "windows-sys 0.48.0",
 ]
@@ -3719,7 +3720,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3793,7 +3794,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn 2.0.59",
+ "syn 2.0.60",
  "which 6.0.1",
 ]
 
@@ -4043,7 +4044,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -4082,7 +4083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
 dependencies = [
  "proc-macro2",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4096,9 +4097,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -4148,7 +4149,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4363,9 +4364,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -4458,9 +4459,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
@@ -4487,13 +4488,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4507,9 +4508,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -4601,9 +4602,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -4800,9 +4801,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.59"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4839,7 +4840,7 @@ checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.2",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
 
@@ -4860,7 +4861,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
@@ -4877,22 +4878,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4991,7 +4992,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5041,7 +5042,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.9",
+ "toml_edit 0.22.12",
 ]
 
 [[package]]
@@ -5068,9 +5069,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.9"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -5157,7 +5158,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5410,7 +5411,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -5444,7 +5445,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5489,7 +5490,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.32",
+ "rustix 0.38.34",
 ]
 
 [[package]]
@@ -5500,7 +5501,7 @@ checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
 dependencies = [
  "either",
  "home",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "winsafe",
 ]
 
@@ -5578,7 +5579,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5589,7 +5590,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5832,7 +5833,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-playdate"
-version = "0.4.5"
+version = "0.4.6"
 readme = "README.md"
 description = "Build tool for neat yellow console."
 keywords = ["playdate", "build", "cargo", "plugin", "cargo-subcommand"]

--- a/cargo/src/main.rs
+++ b/cargo/src/main.rs
@@ -159,7 +159,9 @@ fn execute(config: &Config) -> CargoResult<()> {
 						                    p == package &&
 						                    targets.iter()
 						                           .find(|t| {
-							                           name == t.name() && t.kind().rustc_crate_types().contains(&src_ct)
+							                           let crate_name = t.crate_name();
+							                           (name == &crate_name || &name.replace("-", "_") == &crate_name) &&
+							                           t.kind().rustc_crate_types().contains(&src_ct)
 						                           })
 						                           .is_some()
 					                    })

--- a/cargo/tests/build/simple.rs
+++ b/cargo/tests/build/simple.rs
@@ -63,7 +63,7 @@ fn dev_lib_release() -> Result<()> {
 
 	for path in simple_crates()? {
 		let (_, target_dir) = run_build(&path, args.clone())?;
-		let export_dir = export_dir(&target_dir, target, "release");
+		let export_dir = export_dir(target_dir, target, "release");
 
 		// check expectations:
 		let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
@@ -84,7 +84,7 @@ fn dev_lib_debug() -> Result<()> {
 
 	for path in simple_crates()? {
 		let (_, target_dir) = run_build(&path, args.clone())?;
-		let export_dir = export_dir(&target_dir, target, "debug");
+		let export_dir = export_dir(target_dir, target, "debug");
 
 		// check expectations:
 		let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
@@ -111,7 +111,7 @@ fn sim_host_release() -> Result<()> {
 
 	for path in simple_crates()? {
 		let (_, target_dir) = run_build(&path, args.clone())?;
-		let export_dir = export_dir_host(&target_dir, "release");
+		let export_dir = export_dir_host(target_dir, "release");
 
 		// check expectations:
 		let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
@@ -130,7 +130,7 @@ fn sim_host_release() -> Result<()> {
 fn sim_host_debug() -> Result<()> {
 	for path in simple_crates()? {
 		let (_, target_dir) = run_build(&path, None::<&OsStr>)?;
-		let export_dir = export_dir_host(&target_dir, "debug");
+		let export_dir = export_dir_host(target_dir, "debug");
 
 		// check expectations:
 		let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
@@ -151,7 +151,7 @@ fn sim_host_release_exp() -> Result<()> {
 
 	for path in simple_crates()? {
 		let (_, target_dir) = run_build(&path, args.clone())?;
-		let export_dir = export_dir_host(&target_dir, "release");
+		let export_dir = export_dir_host(target_dir, "release");
 
 		// check expectations:
 		let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
@@ -186,7 +186,7 @@ fn dev_sim_release_exp() -> Result<()> {
 
 		// check expectations:
 		for (filename, target, dev) in &expectations {
-			let export_dir = export_dir(&target_dir, target, "release");
+			let export_dir = export_dir(target_dir, target, "release");
 			let cargo_target_fullname = format!("{cargo_package_name}-{LIB_NAME}");
 			let artifact = export_dir.join("playdate")
 			                         .join(cargo_target_fullname)
@@ -202,7 +202,7 @@ fn dev_sim_release_exp() -> Result<()> {
 
 // (issue: #315) Convert dir-name to package-name, then to crate_name
 fn to_cargo_package_crate_name(path: &Path) -> Option<String> {
-	Some(path.file_name()?.to_str()?.replace("-", "_"))
+	Some(path.file_name()?.to_str()?.replace('-', "_"))
 }
 
 
@@ -220,7 +220,7 @@ mod examples {
 
 		for path in simple_crates()? {
 			let (_, target_dir) = run_build(&path, args.clone())?;
-			let export_dir = export_dir(&target_dir, target, "release");
+			let export_dir = export_dir(target_dir, target, "release");
 
 			// check expectations:
 			let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
@@ -243,7 +243,7 @@ mod examples {
 
 		for path in simple_crates()? {
 			let (_, target_dir) = run_build(&path, args.clone())?;
-			let export_dir = export_dir(&target_dir, target, "release");
+			let export_dir = export_dir(target_dir, target, "release");
 
 			// check expectations:
 			let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
@@ -264,7 +264,7 @@ mod examples {
 
 		for path in simple_crates()? {
 			let (_, target_dir) = run_build(&path, args.clone())?;
-			let export_dir = export_dir(&target_dir, target, "debug");
+			let export_dir = export_dir(target_dir, target, "debug");
 
 			// check expectations:
 			let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
@@ -303,7 +303,7 @@ mod examples {
 
 			// check expectations:
 			for (filename, target, dev) in &expectations {
-				let export_dir = export_dir(&target_dir, target, "release");
+				let export_dir = export_dir(target_dir, target, "release");
 				let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
 				let cargo_target_fullname = format!("{cargo_package_name}-{EXAMPLE_PREFIX}-lib");
 				let artifact = export_dir.join("playdate")

--- a/cargo/tests/build/simple.rs
+++ b/cargo/tests/build/simple.rs
@@ -66,7 +66,7 @@ fn dev_lib_release() -> Result<()> {
 		let export_dir = export_dir(&target_dir, target, "release");
 
 		// check expectations:
-		let cargo_package_name = path.file_name().unwrap().to_str().unwrap();
+		let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
 		let cargo_target_fullname = format!("{cargo_package_name}-{LIB_NAME}");
 		let artifact = export_dir.join("playdate")
 		                         .join(cargo_target_fullname)
@@ -87,7 +87,7 @@ fn dev_lib_debug() -> Result<()> {
 		let export_dir = export_dir(&target_dir, target, "debug");
 
 		// check expectations:
-		let cargo_package_name = path.file_name().unwrap().to_str().unwrap();
+		let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
 		let cargo_target_fullname = format!("{cargo_package_name}-{LIB_NAME}");
 		let artifact = export_dir.join("playdate")
 		                         .join(cargo_target_fullname)
@@ -114,7 +114,7 @@ fn sim_host_release() -> Result<()> {
 		let export_dir = export_dir_host(&target_dir, "release");
 
 		// check expectations:
-		let cargo_package_name = path.file_name().unwrap().to_str().unwrap();
+		let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
 		let cargo_target_fullname = format!("{cargo_package_name}-{LIB_NAME}");
 		let artifact = export_dir.join("playdate")
 		                         .join(cargo_target_fullname)
@@ -133,7 +133,7 @@ fn sim_host_debug() -> Result<()> {
 		let export_dir = export_dir_host(&target_dir, "debug");
 
 		// check expectations:
-		let cargo_package_name = path.file_name().unwrap().to_str().unwrap();
+		let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
 		let cargo_target_fullname = format!("{cargo_package_name}-{LIB_NAME}");
 		let artifact = export_dir.join("playdate")
 		                         .join(cargo_target_fullname)
@@ -154,7 +154,7 @@ fn sim_host_release_exp() -> Result<()> {
 		let export_dir = export_dir_host(&target_dir, "release");
 
 		// check expectations:
-		let cargo_package_name = path.file_name().unwrap().to_str().unwrap();
+		let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
 		let cargo_target_fullname = format!("{cargo_package_name}-{LIB_NAME}");
 		let artifact = export_dir.join("playdate")
 		                         .join(cargo_target_fullname)
@@ -181,13 +181,13 @@ fn dev_sim_release_exp() -> Result<()> {
 	];
 
 	for path in simple_crates()? {
-		let package_name = path.file_name().expect("package_name").to_str().unwrap();
+		let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
 		let (_, target_dir) = run_build(&path, args.clone())?;
 
 		// check expectations:
 		for (filename, target, dev) in &expectations {
 			let export_dir = export_dir(&target_dir, target, "release");
-			let cargo_target_fullname = format!("{package_name}-{LIB_NAME}");
+			let cargo_target_fullname = format!("{cargo_package_name}-{LIB_NAME}");
 			let artifact = export_dir.join("playdate")
 			                         .join(cargo_target_fullname)
 			                         .join("build")
@@ -197,6 +197,12 @@ fn dev_sim_release_exp() -> Result<()> {
 	}
 
 	Ok(())
+}
+
+
+// (issue: #315) Convert dir-name to package-name, then to crate_name
+fn to_cargo_package_crate_name(path: &Path) -> Option<String> {
+	Some(path.file_name()?.to_str()?.replace("-", "_"))
 }
 
 
@@ -217,7 +223,7 @@ mod examples {
 			let export_dir = export_dir(&target_dir, target, "release");
 
 			// check expectations:
-			let cargo_package_name = path.file_name().unwrap().to_str().unwrap();
+			let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
 			let cargo_target_fullname = format!("{cargo_package_name}-{EXAMPLE_PREFIX}-lib");
 			let artifact = export_dir.join("playdate")
 			                         .join(cargo_target_fullname)
@@ -240,7 +246,7 @@ mod examples {
 			let export_dir = export_dir(&target_dir, target, "release");
 
 			// check expectations:
-			let cargo_package_name = path.file_name().unwrap().to_str().unwrap();
+			let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
 			let cargo_target_fullname = format!("{cargo_package_name}-{EXAMPLE_PREFIX}-bin");
 			let artifact = export_dir.join("playdate")
 			                         .join(cargo_target_fullname)
@@ -261,7 +267,7 @@ mod examples {
 			let export_dir = export_dir(&target_dir, target, "debug");
 
 			// check expectations:
-			let cargo_package_name = path.file_name().unwrap().to_str().unwrap();
+			let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
 			let cargo_target_fullname = format!("{cargo_package_name}-{EXAMPLE_PREFIX}-bin");
 			let artifact = export_dir.join("playdate")
 			                         .join(cargo_target_fullname)
@@ -298,7 +304,7 @@ mod examples {
 			// check expectations:
 			for (filename, target, dev) in &expectations {
 				let export_dir = export_dir(&target_dir, target, "release");
-				let cargo_package_name = path.file_name().unwrap().to_str().unwrap();
+				let cargo_package_name = to_cargo_package_crate_name(&path).expect("package_crate_name");
 				let cargo_target_fullname = format!("{cargo_package_name}-{EXAMPLE_PREFIX}-lib");
 				let artifact = export_dir.join("playdate")
 				                         .join(cargo_target_fullname)


### PR DESCRIPTION
Fix #315 "No packages has been produced", caused because cargo changed artefact name format - now replaces dashes with underscores for libs too.

Related cargo PR is [rust-lang/cargo#12783][] which landed will land in Cargo 1.79 (2024-06-13) according to [CHANGELOG][].

It's definitely not a perfect solution, it's just a hot-fix. It should be refactored in the near future.


[rust-lang/cargo#12783]: https://github.com/rust-lang/cargo/pull/12783
[CHANGELOG]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#fixed