### PR TITLE
Fix `panic` & `error`, improve allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4261,7 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "playdate-sys"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "arrayvec",
  "playdate-bindgen",

--- a/api/sys/Cargo.toml
+++ b/api/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "playdate-sys"
-version = "0.3.5"
+version = "0.3.6"
 build = "src/build.rs"
 readme = "README.md"
 description = "Low-level Playdate API bindings"


### PR DESCRIPTION
- Fix `abort` and `panic` to do not crash simulator process (#335)
- Improve global allocator, cache fn-ptr to OS's `realloc` (#336)