### PR TITLE
Update cargo build-script output format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "playdate-bindgen"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bindgen",
  "clap",
@@ -4106,7 +4106,7 @@ dependencies = [
 
 [[package]]
 name = "playdate-bindgen-cfg"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "clap",
 ]
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "playdate-symbolize"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "playdate-sys"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "arrayvec",
  "playdate-bindgen",

--- a/api/sys/Cargo.toml
+++ b/api/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "playdate-sys"
-version = "0.4.1"
+version = "0.4.2"
 build = "src/build.rs"
 readme = "README.md"
 description = "Low-level Playdate API bindings"

--- a/api/sys/src/build.rs
+++ b/api/sys/src/build.rs
@@ -28,7 +28,7 @@ const USE_BUILT_BINDINGS: &str = "PD_BUILD_BINDINGS_ONCE";
 
 
 fn main() {
-	println!("cargo:rerun-if-env-changed={SDK_PATH_ENV_VAR}");
+	println!("cargo::rerun-if-env-changed={SDK_PATH_ENV_VAR}");
 
 	println!("cargo::rustc-check-cfg=cfg(playdate)");
 	if matches!(Target::from_env_target(), Ok(Target::Playdate)) {
@@ -60,7 +60,7 @@ fn main() {
 	let pdbindgen_found = Runner::find_tool(&cfg);
 	if cfg!(feature = "bindgen") && pdbindgen_found.is_some() {
 		println!(
-		         "cargo:warning=Playdate bindgen found but also built as dependency of the {} by enabled feature 'bindgen'. You might want to disable that feature to significantly decrease build time.",
+		         "cargo::warning=Playdate bindgen found but also built as dependency of the {} by enabled feature 'bindgen'. You might want to disable that feature to significantly decrease build time.",
 		         pkg_name
 		);
 		// better wording: significantly speed up the compilation process?
@@ -77,7 +77,7 @@ fn main() {
 		#[cfg(not(feature = "bindgen"))]
 		{
 			let rec = format!("Install it or enable feature 'bindgen' for {pkg_name}.");
-			println!("cargo:warning=Playdate bindgen executable not found. {rec}");
+			println!("cargo::warning=Playdate bindgen executable not found. {rec}");
 			panic!("Unable to find Playdate bindgen executable and feature 'bindgen' disabled, so can't generate bindings.");
 		}
 	}
@@ -97,12 +97,12 @@ fn main() {
 		panic!("Unable to find Playdate SDK and read its version.");
 	}
 	let sdk_version = sdk_version.expect("SDK version");
-	println!("cargo:rustc-env={BINDINGS_VER_ENV}={}", sdk_version);
+	println!("cargo::rustc-env={BINDINGS_VER_ENV}={}", sdk_version);
 
 
 	// get filename
 	let filename = Filename::new(sdk_version, &cfg.derive).expect("output filename");
-	println!("cargo:rustc-env={BINDINGS_NAME_ENV}={}", filename.to_string());
+	println!("cargo::rustc-env={BINDINGS_NAME_ENV}={}", filename.to_string());
 
 
 	// determine output path (prebuilt or OUT_DIR)
@@ -120,7 +120,7 @@ fn main() {
 	} else {
 		#[cfg(feature = "bindgen")]
 		{
-			println!("cargo:warning=Playdate bindgen exited with error. Trying to build without it.");
+			println!("cargo::warning=Playdate bindgen exited with error. Trying to build without it.");
 			return with_builtin_bindgen(cfg);
 		}
 
@@ -139,10 +139,10 @@ fn with_builtin_bindgen(mut cfg: Cfg) {
 	let generator = bindgen::Generator::new(cfg).expect("Couldn't create bindings generator.");
 
 	println!(
-	         "cargo:rustc-env={BINDINGS_NAME_ENV}={}",
+	         "cargo::rustc-env={BINDINGS_NAME_ENV}={}",
 	         generator.filename.to_string()
 	);
-	println!("cargo:rustc-env={BINDINGS_VER_ENV}={}", generator.filename.sdk);
+	println!("cargo::rustc-env={BINDINGS_VER_ENV}={}", generator.filename.sdk);
 
 	// determine output path, also check cache/prebuilt:
 	let out_path = out_path_or_finish_with_prebuilt(&generator.filename);
@@ -179,12 +179,12 @@ fn use_existing_prebuilt(cfg: &Cfg) {
 	println!("using pre-built {version}");
 	let filename = Filename::new(version, &cfg.derive).expect("filename");
 
-	println!("cargo:rustc-env={BINDINGS_VER_ENV}={version}");
-	println!("cargo:rustc-env={BINDINGS_NAME_ENV}={}", filename.to_string());
+	println!("cargo::rustc-env={BINDINGS_VER_ENV}={version}");
+	println!("cargo::rustc-env={BINDINGS_NAME_ENV}={}", filename.to_string());
 
 	let out_path = out_file_prebuilt(&filename);
-	println!("cargo:rerun-if-changed={}", out_path.display());
-	println!("cargo:rustc-env={BINDINGS_PATH_ENV}={}", out_path.display());
+	println!("cargo::rerun-if-changed={}", out_path.display());
+	println!("cargo::rustc-env={BINDINGS_PATH_ENV}={}", out_path.display());
 	assert!(out_path.exists(), "pre-built bindings not found.");
 }
 
@@ -210,12 +210,12 @@ fn out_path_or_finish_with_prebuilt(filename: &Filename) -> PathBuf {
 		println!("rebuild pre-built bindings requested");
 		let out_dir = out_dir_prebuilt();
 		let out_path = out_dir.join(filename.to_string());
-		println!("cargo:rerun-if-changed={}", out_path.display());
-		println!("cargo:warning=Rebuilding `pre-built` bindings");
+		println!("cargo::rerun-if-changed={}", out_path.display());
+		println!("cargo::warning=Rebuilding `pre-built` bindings");
 		if !out_dir.exists() {
 			std::fs::create_dir_all(&out_dir).unwrap();
 			println!(
-			         "cargo:warning=OUT_DIR for `pre-built` bindings created: {}",
+			         "cargo::warning=OUT_DIR for `pre-built` bindings created: {}",
 			         out_dir.display()
 			);
 		}
@@ -226,8 +226,8 @@ fn out_path_or_finish_with_prebuilt(filename: &Filename) -> PathBuf {
 
 		// cache-hit:
 		if out_path.exists() {
-			println!("cargo:rerun-if-changed={}", out_path.display());
-			println!("cargo:rustc-env={BINDINGS_PATH_ENV}={}", out_path.display());
+			println!("cargo::rerun-if-changed={}", out_path.display());
+			println!("cargo::rustc-env={BINDINGS_PATH_ENV}={}", out_path.display());
 			println!("bindings: cache-hit in pre-built directory");
 			exit(0);
 		}
@@ -239,8 +239,8 @@ fn out_path_or_finish_with_prebuilt(filename: &Filename) -> PathBuf {
 		let out_dir_reuse_allowed = env::var_os(USE_BUILT_BINDINGS).filter(|s| s == "1" || s == "true")
 		                                                           .is_some();
 		if out_path.exists() && out_dir_reuse_allowed {
-			println!("cargo:rerun-if-changed={}", out_path.display());
-			println!("cargo:rustc-env={BINDINGS_PATH_ENV}={}", out_path.display());
+			println!("cargo::rerun-if-changed={}", out_path.display());
+			println!("cargo::rustc-env={BINDINGS_PATH_ENV}={}", out_path.display());
 			println!("bindings: cache-hit in build directory");
 			exit(0);
 		}
@@ -248,7 +248,7 @@ fn out_path_or_finish_with_prebuilt(filename: &Filename) -> PathBuf {
 		println!("bindings: cache-miss, continuing");
 		out_path
 	};
-	println!("cargo:rustc-env={BINDINGS_PATH_ENV}={}", out_path.display());
+	println!("cargo::rustc-env={BINDINGS_PATH_ENV}={}", out_path.display());
 
 
 	out_path
@@ -265,7 +265,7 @@ fn is_env_without_sdk() -> bool {
 }
 
 fn is_rebuild_prebuilt_requested() -> bool {
-	println!("cargo:rerun-if-env-changed={BINDINGS_BUILD_PREBUILT}");
+	println!("cargo::rerun-if-env-changed={BINDINGS_BUILD_PREBUILT}");
 	env::var_os(BINDINGS_BUILD_PREBUILT).is_some()
 }
 

--- a/support/addr2line/Cargo.toml
+++ b/support/addr2line/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "playdate-symbolize"
-version = "0.1.0"
+version = "0.1.1"
 readme = "README.md"
 description = "Tools for symbolise addresses from bin (pdex.elf) and Playdate's trace or crashlog."
 keywords = ["playdate", "bin", "elf", "addr2line", "utility"]

--- a/support/addr2line/src/build.rs
+++ b/support/addr2line/src/build.rs
@@ -4,7 +4,7 @@ fn main() {
 		use std::path::PathBuf;
 		let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("symbols.db");
 		let root = root.canonicalize()
-		               .map_err(|err| println!("cargo:warning={err:#}"))
+		               .map_err(|err| println!("cargo::warning={err:#}"))
 		               .unwrap_or(root);
 
 		let src = root.join("src");
@@ -15,7 +15,7 @@ fn main() {
 			std::env::set_var("DATABASE_URL", &url);
 			println!("env var DATABASE_URL has been set to '{url}'.");
 			if !root.exists() {
-				println!("cargo:warning=env var DATABASE_URL isn't set and db doesn't exist.");
+				println!("cargo::warning=env var DATABASE_URL isn't set and db doesn't exist.");
 			}
 		}
 	}

--- a/support/bindgen-cfg/Cargo.toml
+++ b/support/bindgen-cfg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "playdate-bindgen-cfg"
-version = "0.1.6"
+version = "0.1.7"
 readme = "README.md"
 description = "Minimal configuration for playdate-bindgen."
 keywords = ["playdate", "bindings", "ffi", "code-generation"]

--- a/support/bindgen-cfg/src/lib.rs
+++ b/support/bindgen-cfg/src/lib.rs
@@ -228,7 +228,7 @@ impl FromStr for Derive {
 				"partialeq" => this.partialeq = true,
 				"partialord" => this.partialord = true,
 				"constparamty" => this.constparamty = true,
-				_ => println!("cargo:warning=Unknown derive '{word}'."),
+				_ => println!("cargo::warning=Unknown derive '{word}'."),
 			}
 		}
 
@@ -305,7 +305,7 @@ impl FromStr for Features {
 		for word in s.to_ascii_lowercase().split(',') {
 			match word {
 				"documentation" => this.documentation = true,
-				_ => println!("cargo:warning=Unknown feature '{word}'."),
+				_ => println!("cargo::warning=Unknown feature '{word}'."),
 			}
 		}
 

--- a/support/bindgen/Cargo.toml
+++ b/support/bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "playdate-bindgen"
-version = "0.1.10"
+version = "0.1.11"
 readme = "README.md"
 description = "Bindgen configuration for Playdate API and utils."
 keywords = ["playdate", "bindings", "ffi", "code-generation"]

--- a/support/bindgen/src/gen/docs/gen.rs
+++ b/support/bindgen/src/gen/docs/gen.rs
@@ -64,7 +64,7 @@ fn walk_struct(items: &[Cell<Item>],
 								field.attrs.push(attr);
 							} else {
 								#[cfg(feature = "log")]
-								println!("cargo:warning=Doc not found for '{key}'");
+								println!("cargo::warning=Doc not found for '{key}'");
 							}
 						},
 						_ => unimplemented!("unexpected ty: '{}'", quote::quote!(#ty)),

--- a/support/bindgen/src/gen/mod.rs
+++ b/support/bindgen/src/gen/mod.rs
@@ -79,7 +79,7 @@ impl Bindings {
 		let output = match crate::rustfmt(None, source.clone(), None) {
 			Ok(output) => output,
 			Err(err) => {
-				println!("cargo:warning=Rustfmt error: {err}");
+				println!("cargo::warning=Rustfmt error: {err}");
 
 				let output: String;
 				#[cfg(feature = "pretty-please")]

--- a/support/bindgen/src/lib.rs
+++ b/support/bindgen/src/lib.rs
@@ -107,10 +107,10 @@ impl Generator {
 
 
 fn create_generator(cfg: cfg::Cfg) -> Result<Generator, error::Error> {
-	println!("cargo:rerun-if-env-changed=TARGET");
+	println!("cargo::rerun-if-env-changed=TARGET");
 	let cargo_target_triple = env::var("TARGET").expect("TARGET cargo env var");
 
-	println!("cargo:rerun-if-env-changed=PROFILE");
+	println!("cargo::rerun-if-env-changed=PROFILE");
 	let cargo_profile = env::var("PROFILE").expect("PROFILE cargo env var");
 	let is_debug = cargo_profile == "debug" || env_cargo_feature("DEBUG");
 
@@ -120,13 +120,13 @@ fn create_generator(cfg: cfg::Cfg) -> Result<Generator, error::Error> {
 	let version_path = sdk.version_file();
 	let version_raw = sdk.read_version()?;
 	let version = check_sdk_version(&version_raw)?;
-	println!("cargo:rerun-if-changed={}", version_path.display());
+	println!("cargo::rerun-if-changed={}", version_path.display());
 	let sdk_c_api = sdk.c_api();
 
 	let main_header = sdk_c_api.join("pd_api.h");
-	println!("cargo:rerun-if-changed={}", main_header.display());
-	println!("cargo:rerun-if-env-changed={SDK_ENV_VAR}");
-	println!("cargo:include={}", sdk_c_api.display());
+	println!("cargo::rerun-if-changed={}", main_header.display());
+	println!("cargo::rerun-if-env-changed={SDK_ENV_VAR}");
+	println!("cargo::include={}", sdk_c_api.display());
 
 
 	// builder:
@@ -287,8 +287,8 @@ fn apply_profile(mut builder: Builder, debug: bool) -> Builder {
 fn apply_target(mut builder: Builder, target: &str, gcc: &ArmToolchain) -> Builder {
 	builder = if DEVICE_TARGET == target {
 		let arm_eabi_include = gcc.include();
-		// println!("cargo:rustc-link-search={}", arm_eabi.join("lib").display()); // for executable
-		println!("cargo:include={}", arm_eabi_include.display());
+		// println!("cargo::rustc-link-search={}", arm_eabi.join("lib").display()); // for executable
+		println!("cargo::include={}", arm_eabi_include.display());
 
 		// TODO: prevent build this for other targets:
 		// builder = builder.raw_line(format!("#![cfg(target = \"{DEVICE_TARGET}\")]\n\n"));

--- a/support/bindgen/src/lib.rs
+++ b/support/bindgen/src/lib.rs
@@ -126,7 +126,7 @@ fn create_generator(cfg: cfg::Cfg) -> Result<Generator, error::Error> {
 	let main_header = sdk_c_api.join("pd_api.h");
 	println!("cargo::rerun-if-changed={}", main_header.display());
 	println!("cargo::rerun-if-env-changed={SDK_ENV_VAR}");
-	println!("cargo::include={}", sdk_c_api.display());
+	println!("cargo::metadata=include={}", sdk_c_api.display());
 
 
 	// builder:
@@ -288,7 +288,7 @@ fn apply_target(mut builder: Builder, target: &str, gcc: &ArmToolchain) -> Build
 	builder = if DEVICE_TARGET == target {
 		let arm_eabi_include = gcc.include();
 		// println!("cargo::rustc-link-search={}", arm_eabi.join("lib").display()); // for executable
-		println!("cargo::include={}", arm_eabi_include.display());
+		println!("cargo::metadata=include={}", arm_eabi_include.display());
 
 		// TODO: prevent build this for other targets:
 		// builder = builder.raw_line(format!("#![cfg(target = \"{DEVICE_TARGET}\")]\n\n"));


### PR DESCRIPTION
Update cargo build-script output format to new that actual from rust 1.77.
Old format is deprecated.