### PR TITLE
Fix assets planning should be compile-kind agnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-playdate"
-version = "0.5.0-beta.3"
+version = "0.5.0-beta.4"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2759,9 +2759,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8720bf4c5bfb5b6c350840c4cd14b787bf00ed51c148c857fbf7a6ddb7062764"
+checksum = "9f3935c160d00ac752e09787e6e6bfc26494c2183cc922f1bc678a60d4733bc2"
 
 [[package]]
 name = "httpdate"
@@ -4182,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "playdate-build"
-version = "0.4.0-pre2"
+version = "0.4.0-pre3"
 dependencies = [
  "dirs",
  "fs_extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ system = { version = "0.3", path = "api/system", package = "playdate-system", de
 sys = { version = "0.4", path = "api/sys", package = "playdate-sys", default-features = false }
 
 tool = { version = "0.1", path = "support/tool", package = "playdate-tool" }
-build = { version = "=0.4.0-pre2", path = "support/build", package = "playdate-build", default-features = false }
+build = { version = "=0.4.0-pre3", path = "support/build", package = "playdate-build", default-features = false }
 utils = { version = "0.3", path = "support/utils", package = "playdate-build-utils", default-features = false }
 device = { version = "0.2", path = "support/device", package = "playdate-device" }
 simulator = { version = "0.1", path = "support/sim-ctrl", package = "playdate-simulator-utils", default-features = false }

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-playdate"
-version = "0.5.0-beta.3"
+version = "0.5.0-beta.4"
 readme = "README.md"
 description = "Build tool for neat yellow console."
 keywords = ["playdate", "build", "cargo", "plugin", "cargo-subcommand"]

--- a/cargo/src/assets/mod.rs
+++ b/cargo/src/assets/mod.rs
@@ -368,7 +368,7 @@ pub mod proto {
 		}
 
 		let serializable = SerializablePlan { items: &serializable,
-		                               env: plan.used_env_vars() };
+		                                      env: plan.used_env_vars() };
 		let json = serde_json::to_string(&serializable)?;
 
 		let difference = if path.try_exists()? {

--- a/cargo/src/main.rs
+++ b/cargo/src/main.rs
@@ -64,7 +64,8 @@ fn main() -> CargoResult<()> {
 fn execute(config: &Config) -> CargoResult<()> {
 	match config.cmd {
 		cli::cmd::Cmd::Assets => {
-			let _result = assets::build(config)?;
+			let deps_tree = crate::utils::cargo::meta_deps::meta_deps(config)?;
+			assets::proto::build_all(config, &deps_tree)?;
 		},
 
 		cli::cmd::Cmd::Build => {

--- a/cargo/src/utils/cargo/meta_deps.rs
+++ b/cargo/src/utils/cargo/meta_deps.rs
@@ -277,9 +277,7 @@ impl<'t> MetaDeps<'t> {
 	pub fn roots_by_compile_target(&self) -> BTreeMap<TargetKey, BTreeSet<cargo::core::compiler::CompileKind>> {
 		self.roots.iter().fold(BTreeMap::new(), |mut acc, root| {
 			                 let key = TargetKey::from(root);
-			                 acc.entry(key)
-			                    .or_default()
-			                    .insert(root.node().unit().platform);
+			                 acc.entry(key).or_default().insert(root.node().unit().platform);
 			                 acc
 		                 })
 	}

--- a/cargo/src/utils/cargo/meta_deps.rs
+++ b/cargo/src/utils/cargo/meta_deps.rs
@@ -278,7 +278,7 @@ impl<'t> MetaDeps<'t> {
 		self.roots.iter().fold(BTreeMap::new(), |mut acc, root| {
 			                 let key = TargetKey::from(root);
 			                 acc.entry(key)
-			                    .or_insert(BTreeSet::new())
+			                    .or_default()
 			                    .insert(root.node().unit().platform);
 			                 acc
 		                 })

--- a/support/build/Cargo.toml
+++ b/support/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "playdate-build"
-version = "0.4.0-pre2"
+version = "0.4.0-pre3"
 readme = "README.md"
 description = "Utils that help to build package for Playdate"
 keywords = ["playdate", "package", "encoding", "manifest", "assets"]


### PR DESCRIPTION
Following #376

- fix assets-build-planner
- plan compile-kind agnostic
- improve build-plan cache, add resolved env vars

To reproduce:
1. prepare package with 
    - lib
    - more then one bins, including `main.rs` as auto-target
    - some example(s)
1. run:
    ```bash
    cargo build -p=cargo-playdate && \
    CARGO_PLAYDATE_LOG="trace" RUST_LOG="trace" ./target/debug/cargo-playdate assets -vvv \
    --target-dir=./target-dev-test \
    -p=test-workspace-main-crate \
    --manifest-path=${PREPARED_PACKAGE_FROM_STEP_1}/Cargo.toml \
    --target=thumbv7em-none-eabihf --target=your-host-target \
    -- --examples --bins --lib # or --all-targets
    ```