### PR TITLE
Minor Improvements to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Follow the instructions for:
 
 Run example:
 ```bash
-cargo run -p=cargo-playdate -- run -p=playdate-controls --example=buttons
+cargo run -p=cargo-playdate -- run -p=playdate-controls --example=buttons --features="sys/lang-items sys/entry-point"
 ```
 
 Install `cargo-playdate` and build & run another example:
 ```bash
 cargo install cargo-playdate
-cargo playdate run -p=playdate-sound --example=sp
-cargo playdate run -p=playdate-sound --example=sp --device
+cargo playdate run -p=playdate-sound --example=sp --features="sys/lang-items sys/entry-point"
+cargo playdate run -p=playdate-sound --example=sp --features="sys/lang-items sys/entry-point" --device
 ```
 
 ### Demo

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ cargo run -p=cargo-playdate -- run -p=playdate-controls --example=buttons
 Install `cargo-playdate` and build & run another example:
 ```bash
 cargo install cargo-playdate
-cargo playdate run -p=playdate-sound --example=sp-simple
-cargo playdate run -p=playdate-sound --example=sp-simple --device
+cargo playdate run -p=playdate-sound --example=sp
+cargo playdate run -p=playdate-sound --example=sp --device
 ```
 
 ### Demo


### PR DESCRIPTION
This pull request covers some minor improvements to the README. These consist of:
* Fixing the `playdate-sound` example to use the actual example name, `sp`, instead of the source file name, `sp-simple`
* Add the required feature flag to all example commands. When I first ran these locally, compilation failed due to the required features not being met.