### PR TITLE
CI: run rustup warmup in background on win only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,6 +149,7 @@ jobs:
         uses: ./.github/actions/init-cfg
 
       - name: Rustup warmup
+        if: runner.os == 'Windows'
         run: rustup show &
 
       - name: Install Deps
@@ -207,6 +208,7 @@ jobs:
         uses: ./.github/actions/init-cfg
 
       - name: Rustup warmup
+        if: runner.os == 'Windows'
         run: rustup show &
 
       - name: Install Deps
@@ -261,6 +263,7 @@ jobs:
         uses: ./.github/actions/init-cfg
 
       - name: Rustup warmup
+        if: runner.os == 'Windows'
         run: rustup show &
 
       - name: Install Deps
@@ -318,6 +321,7 @@ jobs:
         uses: ./.github/actions/init-cfg
 
       - name: Rustup warmup
+        if: runner.os == 'Windows'
         run: rustup show &
 
       - name: Install Deps
@@ -391,6 +395,7 @@ jobs:
           cargo clean
 
       - name: Rustup warmup
+        if: runner.os == 'Windows'
         run: rustup show &
 
       - name: Install Deps


### PR DESCRIPTION
Should fix [this][first] and [that][second].

[first]: https://github.com/boozook/playdate/actions/runs/13381497082/job/37370711120
[second]: https://github.com/boozook/playdate/actions/runs/13391497435/job/37400042778?pr=495