### PR TITLE
New `playdate-allocator`

### DIFF
--- a/api/allocator/Cargo.toml
+++ b/api/allocator/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "playdate-allocator"
+version = "0.1.0"
+readme = "README.md"
+description = "Global allocator and allocator-api implementation for Playdate"
+keywords = ["playdate", "allocator", "allocator-api", "gamedev"]
+categories = ["memory-management", "external-ffi-bindings", "api-bindings", "game-development", "no-std"]
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = true
+
+[dependencies]
+
+
+[features]
+default = []
+
+global = [] # Global allocator (system)
+local = []  # Implementation of `allocator-api`
+
+# Link statically `realloc` c-fn, otherwise store `realloc` in the static mut and reqires init.
+static-link = []
+
+global-error-handler = [] # Optional global OoM handler, panics.

--- a/api/allocator/README.md
+++ b/api/allocator/README.md
@@ -1,0 +1,1 @@
+Global allocator and allocator-api implementation for Playdate.

--- a/api/allocator/src/global.rs
+++ b/api/allocator/src/global.rs
@@ -1,0 +1,59 @@
+use core::alloc::{GlobalAlloc, Layout};
+use core::ffi::c_void;
+
+use crate::System;
+
+
+/// Global Playdate [System] allocator.
+#[global_allocator]
+#[cfg(feature = "global")]
+pub static GLOBAL: System = System;
+
+
+/// Global handler for an Out Of Memory (OOM) condition
+#[alloc_error_handler]
+#[cfg(feature = "global-error-handler")]
+fn alloc_error(layout: Layout) -> ! {
+	// TODO: Here could be alloc-less panic.
+	// But it can be implemented to use string-on-heap for formatting.
+	// So should here be just call `playdate.sys.error`?
+	panic!("OoM: {}b", layout.size()) // very short str is to minimize potential allocation anyway.
+}
+
+
+unsafe impl GlobalAlloc for System {
+	#[inline]
+	unsafe fn alloc(&self, layout: Layout) -> *mut u8 { realloc(core::ptr::null_mut(), layout.size()) as *mut u8 }
+	#[inline]
+	unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) { dealloc(ptr as *mut c_void); }
+	#[inline]
+	unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+		let res = realloc(ptr as *mut c_void, new_size) as *mut u8;
+
+		// default mem-copy- behavior if new != old:
+		if !res.is_null() && ptr != res {
+			// SAFETY: the previously allocated block cannot overlap the newly allocated block.
+			// The safety contract for `dealloc` must be upheld by the caller.
+			unsafe {
+				core::ptr::copy_nonoverlapping(ptr, res, core::cmp::min(layout.size(), new_size));
+				self.dealloc(ptr, layout);
+			}
+		}
+
+		res
+	}
+
+	// `alloc_zeroed` is default impl because Playdate's system allocator
+	// as well as Symulator's returns NOT-zeroed memory.
+	// alloc's default impl is fills zeroes after allocation.
+}
+
+
+#[track_caller]
+#[inline(always)]
+pub unsafe fn realloc(ptr: *mut c_void, size: usize) -> *mut c_void { crate::get()(ptr, size) }
+
+
+#[track_caller]
+#[inline(always)]
+pub unsafe fn dealloc(ptr: *mut c_void) { realloc(ptr, 0); }

--- a/api/allocator/src/lib.rs
+++ b/api/allocator/src/lib.rs
@@ -1,0 +1,180 @@
+#![no_std]
+#![cfg_attr(feature = "local", feature(allocator_api, slice_ptr_get))]
+#![cfg_attr(feature = "global", feature(alloc_error_handler))]
+#![cfg_attr(any(test, debug_assertions, not(feature = "static-link")),
+            feature(fn_ptr_trait))]
+
+
+// extern crate alloc;
+
+
+#[cfg(feature = "local")]
+pub mod local;
+pub mod global;
+
+
+/// PlaydateOs system allocator.
+///
+/// Allocator uses system `realloc` c-fn,
+/// so user have to call [`init`] if `static-link` feature is disabled.
+///
+/// Otherwise if `static-link` is on, it's statically linked and it's nesessary to call [`init`].
+pub struct System;
+
+
+type Realloc = unsafe extern "C" fn(ptr: *mut c_void, size: usize) -> *mut c_void;
+
+
+use core::ffi::c_void;
+
+/// Fn-pointer to the OS's realloc function.
+#[cfg(not(feature = "static-link"))]
+static mut REALLOC: Realloc = fake;
+
+
+/// Fake no-op realloc function, used as initial value (instead of any kinds of null) of [`REALLOC`].
+/// Using this function will cause allocation failures.
+#[cold]
+#[cfg(not(feature = "static-link"))]
+unsafe extern "C" fn fake(_: *mut c_void, _: usize) -> *mut c_void { core::ptr::null_mut() }
+
+
+unsafe extern "C" {
+	/// Statically linked OS's realloc function.
+	#[cfg(feature = "static-link")]
+	fn pdrealloc(ptr: *mut c_void, size: usize) -> *mut c_void;
+}
+
+
+#[inline(always)]
+#[cfg(debug_assertions)]
+pub fn init(realloc: Realloc) {
+	use core::marker::FnPtr;
+
+	debug_assert!(!realloc.addr().is_null());
+	init_realloc(realloc)
+}
+
+
+#[inline(always)]
+#[cfg(not(debug_assertions))]
+pub const fn init(realloc: Realloc) { init_realloc(realloc) }
+
+
+#[inline(always)]
+#[cfg_attr(feature = "static-link",
+           doc = "\n no-op because [`realloc`] is linked statically")]
+const fn init_realloc(#[cfg_attr(feature = "static-link", allow(unused_variables))] realloc: Realloc) {
+	#[cfg(not(feature = "static-link"))]
+	unsafe {
+		REALLOC = realloc
+	}
+}
+
+#[inline(always)]
+#[cfg(feature = "static-link")]
+pub const fn is_inited() -> bool { true }
+
+
+#[cfg(not(feature = "static-link"))]
+pub fn is_inited() -> bool {
+	use core::ptr::fn_addr_eq;
+	unsafe { !fn_addr_eq(REALLOC, fake as Realloc) }
+}
+
+
+#[inline(always)]
+#[cfg(debug_assertions)]
+fn get() -> Realloc {
+	let realloc = get_unchecked();
+
+	#[cfg(not(feature = "static-link"))]
+	debug_assert!(!core::marker::FnPtr::addr(realloc).is_null(), "missed realloc");
+
+	realloc
+}
+
+#[inline(always)]
+#[cfg(not(debug_assertions))]
+const fn get() -> Realloc { get_unchecked() }
+
+
+#[inline(always)]
+const fn get_unchecked() -> Realloc {
+	#[cfg(feature = "static-link")]
+	{
+		pdrealloc
+	}
+	#[cfg(not(feature = "static-link"))]
+	{
+		unsafe { REALLOC }
+	}
+}
+
+
+#[cfg(test)]
+#[cfg(not(feature = "global"))]
+mod tests {
+	#![allow(unexpected_cfgs)] // for `fake_alloc`.
+	// It could be properly registered by adding to build-script `println!("cargo::rustc-check-cfg=cfg(fake_alloc)")`,
+	// but it's only needed for tests and should not used in production,
+	// so could be great if compiler warn about it in places other than tests.
+
+	use core::ptr::null_mut;
+	use super::*;
+
+
+	#[test]
+	#[cfg_attr(feature = "static-link", ignore = "for static-mut only")]
+	fn not_inited() {
+		#[cfg(not(feature = "static-link"))]
+		unsafe {
+			REALLOC = fake
+		}
+		assert!(!is_inited());
+	}
+
+	#[test]
+	fn inited() {
+		#[cfg(not(feature = "static-link"))]
+		{
+			unsafe { REALLOC = fake }
+			assert!(!is_inited());
+		}
+
+		init_fake();
+
+		assert!(is_inited());
+
+		#[cfg(feature = "static-link")]
+		assert!(!core::marker::FnPtr::addr(pdrealloc as Realloc).is_null());
+	}
+
+
+	#[test]
+	#[cfg_attr(not(fake_alloc), ignore = "set RUSTFLAGS='--cfg=fake_alloc' to enable.")]
+	fn get_alloc_fake() {
+		init_fake();
+
+		let realloc = get();
+		let p = unsafe { realloc(null_mut(), 64) };
+
+		assert!(p.is_null());
+	}
+
+
+	pub(crate) fn init_fake() {
+		#[cfg(not(feature = "static-link"))]
+		{
+			// another fake, mem-location is different from crate::fake
+			unsafe extern "C" fn fake(_: *mut c_void, _: usize) -> *mut c_void { null_mut() }
+			unsafe { REALLOC = fake }
+		}
+	}
+
+
+	#[no_mangle]
+	#[cfg(fake_alloc)]
+	#[cfg(feature = "static-link")]
+	extern "C" fn pdrealloc(_: *mut c_void, _: usize) -> *mut c_void { null_mut() }
+}

--- a/api/allocator/src/local.rs
+++ b/api/allocator/src/local.rs
@@ -1,0 +1,199 @@
+use core::alloc::Allocator;
+use core::alloc::AllocError;
+use core::alloc::Layout;
+use core::ptr::NonNull;
+use core::ptr::null_mut;
+use core::ptr::slice_from_raw_parts_mut;
+
+use crate::global::dealloc;
+use crate::global::realloc;
+use crate::System;
+
+
+unsafe impl Allocator for System {
+	/// Attempts to allocate a block of memory.
+	///
+	/// Returns a new `NonNull<[u8]>` if the allocation was successful.
+	/// The returned block of memory is not zeroed.
+	///
+	/// # Errors
+	///
+	/// Returning `Err` indicates that either memory is exhausted or `layout` does
+	/// not meet allocator's size or alignment constraints,
+	/// as well as [`init`](crate::init) was not called.
+	///
+	/// See more details on [`Allocator`](core::alloc::Allocator::allocate).
+	fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+		debug_assert!(crate::is_inited());
+
+		let p = unsafe { realloc(null_mut(), layout.size()) };
+
+		if p.is_null() {
+			Err(AllocError)
+		} else {
+			let p = slice_from_raw_parts_mut(p.cast(), layout.size());
+			Ok(unsafe { NonNull::new_unchecked(p) })
+		}
+	}
+
+	/// Deallocates the memory referenced by `ptr`.
+	///
+	/// Note: ignores layout, just deallocates region which is internally associated with given ptr.
+	///
+	/// See more details on [`Allocator`](core::alloc::Allocator::deallocate).
+	unsafe fn deallocate(&self, ptr: NonNull<u8>, _layout: Layout) {
+		debug_assert!(crate::is_inited());
+
+		unsafe { dealloc(ptr.as_ptr().cast()) };
+	}
+
+
+	// `allocate_zeroed` is default impl because Playdate's system allocator
+	// as well as Symulator's returns NOT-zeroed memory.
+	// alloc's default impl is fills zeroes after allocation.
+
+
+	unsafe fn grow(&self,
+	               ptr: NonNull<u8>,
+	               old_layout: Layout,
+	               new_layout: Layout)
+	               -> Result<NonNull<[u8]>, AllocError> {
+		debug_assert!(
+		              new_layout.size() >= old_layout.size(),
+		              "`new_layout.size()` must be greater than or equal to `old_layout.size()`"
+		);
+		debug_assert!(crate::is_inited());
+
+		let new_ptr: *mut u8 = realloc(ptr.as_ptr().cast(), new_layout.size()).cast();
+
+		let new_ptr = if new_ptr.is_null() {
+			return Err(AllocError);
+		} else {
+			let new_ptr = slice_from_raw_parts_mut(new_ptr, new_layout.size());
+			unsafe { NonNull::new_unchecked(new_ptr) }
+		};
+
+		if ptr != new_ptr.as_non_null_ptr() {
+			// SAFETY: because `new_layout.size()` must be greater than or equal to
+			// `old_layout.size()`, both the old and new memory allocation are valid for reads and
+			// writes for `old_layout.size()` bytes. Also, because the old allocation wasn't yet
+			// deallocated, it cannot overlap `new_ptr`. Thus, the call to `copy_nonoverlapping` is
+			// safe. The safety contract for `dealloc` must be upheld by the caller.
+			unsafe {
+				core::ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_mut_ptr(), old_layout.size());
+				self.deallocate(ptr, old_layout);
+			}
+		}
+
+		Ok(new_ptr)
+	}
+
+	unsafe fn grow_zeroed(&self,
+	                      ptr: NonNull<u8>,
+	                      old_layout: Layout,
+	                      new_layout: Layout)
+	                      -> Result<NonNull<[u8]>, AllocError> {
+		debug_assert!(
+		              new_layout.size() >= old_layout.size(),
+		              "`new_layout.size()` must be greater than or equal to `old_layout.size()`"
+		);
+		debug_assert!(crate::is_inited());
+
+		let new_ptr = self.grow(ptr, old_layout, new_layout)?;
+
+		// zeroing new mem only:
+		let size = new_layout.size() - old_layout.size();
+		let ext = ptr.add(old_layout.size());
+		unsafe { ext.as_ptr().write_bytes(0, size) }
+
+		Ok(new_ptr)
+	}
+
+	unsafe fn shrink(&self,
+	                 ptr: NonNull<u8>,
+	                 old_layout: Layout,
+	                 new_layout: Layout)
+	                 -> Result<NonNull<[u8]>, AllocError> {
+		debug_assert!(
+		              new_layout.size() <= old_layout.size(),
+		              "`new_layout.size()` must be smaller than or equal to `old_layout.size()`"
+		);
+		debug_assert!(crate::is_inited());
+
+		// trying to shrink using realloc
+		let new_ptr: *mut u8 = realloc(ptr.as_ptr().cast(), new_layout.size()).cast();
+
+		let new_ptr = if new_ptr.is_null() {
+			// re-allocate and copy to new location
+			let new_ptr = self.allocate(new_layout)?;
+			// SAFETY: because `new_layout.size()` must be lower than or equal to
+			// `old_layout.size()`, both the old and new memory allocation are valid for reads and
+			// writes for `new_layout.size()` bytes. Also, because the old allocation wasn't yet
+			// deallocated, it cannot overlap `new_ptr`. Thus, the call to `copy_nonoverlapping` is
+			// safe. The safety contract for `dealloc` must be upheld by the caller.
+			unsafe {
+				core::ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_mut_ptr(), new_layout.size());
+				self.deallocate(ptr, old_layout);
+			}
+			new_ptr
+		} else {
+			let new_ptr = slice_from_raw_parts_mut(new_ptr, new_layout.size());
+			unsafe { NonNull::new_unchecked(new_ptr) }
+		};
+
+		Ok(new_ptr)
+	}
+}
+
+
+#[cfg(test)]
+#[cfg(not(feature = "global"))]
+mod tests {
+	#![allow(unexpected_cfgs)] // for `fake_alloc`, see explanation in crate::tests.
+
+	use super::*;
+
+
+	#[test]
+	#[cfg_attr(feature = "static-link", ignore = "for static-mut only")]
+	fn not_inited() {
+		#[cfg(not(feature = "static-link"))]
+		unsafe {
+			crate::REALLOC = crate::fake as crate::Realloc;
+		};
+
+		assert!(!crate::is_inited());
+	}
+
+	#[test]
+	#[cfg_attr(debug_assertions, should_panic)]
+	#[cfg_attr(feature = "static-link", ignore = "for static-mut only")]
+	fn allocate_not_inited() {
+		#[cfg(not(feature = "static-link"))]
+		unsafe {
+			crate::REALLOC = crate::fake as crate::Realloc;
+		};
+
+		assert!(!crate::is_inited());
+
+		let l = unsafe { Layout::from_size_align_unchecked(size_of::<usize>(), align_of::<usize>()) };
+		assert!(System.allocate(l).is_err())
+	}
+
+
+	#[test]
+	#[cfg_attr(not(fake_alloc), ignore = "set RUSTFLAGS='--cfg=fake_alloc' to enable.")]
+	fn inited_fake() {
+		crate::tests::init_fake();
+		assert!(crate::is_inited());
+	}
+
+	#[test]
+	#[cfg_attr(not(fake_alloc), ignore = "set RUSTFLAGS='--cfg=fake_alloc' to enable.")]
+	fn allocate_fake() {
+		crate::tests::init_fake();
+
+		let l = unsafe { Layout::from_size_align_unchecked(size_of::<usize>(), align_of::<usize>()) };
+		assert!(System.allocate(l).is_err())
+	}
+}


### PR DESCRIPTION
* added new `playdate-allocator` as standalone crate
* contains:
  - global allocator impl
  - non-global allocator - `allocator-api` impl
  - global OoM-handler
  - ☝🏻all is optional
* two ways to use within any env:
  - `static mut` with `realloc` fn
  - unsafe statically linked `realloc` fn (sym name is "pdrealloc" to not to be confused with the host-system's one)