### PR TITLE
fix small typo that prevents building

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,3 @@ rustflags = [
 	'--cfg=pdtrace="cb-rem"',
 	# '--cfg=pdtrace="cb-into"',
 ]
-	'--cfg=pdtrace="cb-add"',
-	'--cfg=pdtrace="cb-rem"',
-	# '--cfg=pdtrace="cb-into"',
-]


### PR DESCRIPTION
trying to cargo install cargo-playdate (or build in general) from the api-refactoring branch gives the following error
```
error: key with no value, expected `=`
   --> ../Cargo.toml:119:26
    |
119 |     '--cfg=pdtrace="cb-add"',
    |                             ^
error: failed to parse manifest at `/Users/coztellation/Documents/programming/playdate/playdate/cargo/Cargo.toml`

Caused by:
  error inheriting `edition` from workspace root manifest's `workspace.package.edition`
```

which seems to be caused by commit f78f6b4 accidentally doubling up on some compiler flags and making cargo mad
removing these four duplicate lines made compiling & installing work on my system

also this is my first pull request so i hope i did it correctly lol